### PR TITLE
Rebar does not support $MAKE (to my knowledge), so use a shim makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,44 @@
+REPO		?= faulterl
+FAULTERL_TAG	 = $(shell git describe --tags)
+REVISION	?= $(shell echo $(FAULTERL_TAG) | sed -e 's/^$(REPO)-//')
+PKG_VERSION	?= $(shell echo $(REVISION) | tr - .)
+BASE_DIR         = $(shell pwd)
+REBAR_BIN := $(shell which rebar)
+ifeq ($(REBAR_BIN),)
+REBAR_BIN = ./rebar
+endif
+
+.PHONY: rel deps package pkgclean
+
+all: compile
+
+# rebar_post_compile is typically only used by Rebar's post_hooks.
+rebar_post_compile: compile_scripts compile_scenarios
+
+compile:
+	$(REBAR_BIN) compile
+
+clean:
+	$(REBAR_BIN) clean
+	rm -f ebin/*.escript
+	rm -f ebin/*.sh
+
+compile_scripts: ebin/make_intercept_c.escript \
+                 ebin/example_environment.sh
+
+compile_scenarios:
+	erlc +debug_info -o ebin -I include priv/scenario/*erl
+
+ebin/make_intercept_c.escript: priv/scripts/make_intercept_c.escript
+	echo "#!/usr/bin/env escript" > $@
+	echo "%%! -pz $(PWD)/ebin" >> $@
+	cat $< >> $@
+	chmod +x $@
+
+ebin/example_environment.sh: priv/scripts/example_environment.sh
+	cp -p $< $@
+
+test: compile eunit
+
+eunit:
+	$(REBAR_BIN) -v skip_deps=true eunit

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,4 @@
-REPO		?= faulterl
-FAULTERL_TAG	 = $(shell git describe --tags)
-REVISION	?= $(shell echo $(FAULTERL_TAG) | sed -e 's/^$(REPO)-//')
-PKG_VERSION	?= $(shell echo $(REVISION) | tr - .)
-BASE_DIR         = $(shell pwd)
-REBAR_BIN := $(shell which rebar)
-ifeq ($(REBAR_BIN),)
-REBAR_BIN = ./rebar
-endif
-
-.PHONY: rel deps package pkgclean
-
-all: compile
-
-# rebar_post_compile is typically only used by Rebar's post_hooks.
-rebar_post_compile: compile_scripts compile_scenarios
-
-compile:
-	$(REBAR_BIN) compile
-
-clean:
-	$(REBAR_BIN) clean
-	rm -f ebin/*.escript
-	rm -f ebin/*.sh
-
-compile_scripts: ebin/make_intercept_c.escript \
-                 ebin/example_environment.sh
-
-compile_scenarios:
-	erlc +debug_info -o ebin -I include priv/scenario/*erl
-
-ebin/make_intercept_c.escript: priv/scripts/make_intercept_c.escript
-	echo "#!/usr/bin/env escript" > $@
-	echo "%%! -pz $(PWD)/ebin" >> $@
-	cat $< >> $@
-	chmod +x $@
-
-ebin/example_environment.sh: priv/scripts/example_environment.sh
-	cp -p $< $@
-
-test: compile eunit
-
-eunit:
-	$(REBAR_BIN) -v skip_deps=true eunit
+# stub for when rebar calls 'make' and 'make' is BSD make
+# see GNUmakefile for the real makefile
+rebar_post_compile:
+	@gmake rebar_post_compile


### PR DESCRIPTION
GNU make will look for GNUmakefile before Makefile, so move the makefile
over there and add a stub Makefile that simply defines the target that
rebar tries to build. This fixes the case where make is not gnu make.

cc @jaredmorrow
